### PR TITLE
build(package.json): define a versão mínima do Node.js que suporta o código

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "C4bret",
+  "engines": {
+    "node": ">=15.0.0"
+  },
   "version": "1.0.0",
   "description": "Implementação de Automato com pilha. Trabalho final da disciplina de Linguagens Formais e Autômatos. UFPA-2021-1",
   "main": "index.js",


### PR DESCRIPTION
Foi constatado que código utiliza uma função `replaceAll()` que não é presente em engine desatualizadas. Por isso foi definida a versão mínima do Node.js, `v15.0.0`, que dá suporte ao código.